### PR TITLE
docs(themes/Shiro): fix theme config

### DIFF
--- a/pages/themes/shiro.mdx
+++ b/pages/themes/shiro.mdx
@@ -217,7 +217,7 @@ import { EnvVariableConfig } from '@components/EnvVariableConfig';
       "bilibili": {
         "liveId": 1434499
       }
-    },
+    }
   }
 }
 ```


### PR DESCRIPTION
Shiro 主题配置示例多了个逗号导致直接复制修改的配置文件无法正常保存（