### PR TITLE
docs: fix `docsRepositoryBase` to correct edit link

### DIFF
--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -70,7 +70,7 @@ const config: DocsThemeConfig = {
   project: {
     link: 'https://github.com/mx-space/core',
   },
-  docsRepositoryBase: 'https://github.com/mx-space/docs',
+  docsRepositoryBase: 'https://github.com/mx-space/docs/blob/main/pages',
   footer: {
     text: (
       <div className="flex w-full flex-col items-center sm:items-start">


### PR DESCRIPTION
按照 [Nextra 官方文档](https://nextra.site/docs/docs-theme/theme-configuration#edit-link)尝试修了下编辑连接错误的问题（