### PR TITLE
docs: a more accurate description of the "相关内容" content

### DIFF
--- a/pages/docs/_meta.json
+++ b/pages/docs/_meta.json
@@ -8,6 +8,6 @@
   "docker": "Docker 部署",
   "scripts": "预设脚本部署",
   "advanced": "进阶部署",
-  "extra": "拓展内容",
+  "extra": "相关内容",
   "community": "社区分享"
 }

--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -38,7 +38,7 @@ import { UilExternalLinkAlt } from '@components/Icons/ExternalLinkAlt';
   <Card arrow title="预设脚本部署" href="/docs/scripts" icon={<UilPaintTool />} />
   <Card arrow title="进阶部署" href="/docs/advanced" icon={<UimStar />} />
   <Card arrow title="社区部署教程" href="/docs/community" icon={<FluentPeopleCommunity />} />
-  <Card arrow title="部署扩展内容" href="/docs/extra" icon={<UilExternalLinkAlt />} />
+  <Card arrow title="相关内容" href="/docs/extra" icon={<UilExternalLinkAlt />} />
 </Cards>
 
 还有更多部署方式吗？欢迎您向文档提交 [Pull Request](https://github.com/mx-space/docs/pulls) 以分享您的部署方式。按上方**后端部署文档**完成你的部署后，你可以通过下面的方式继续部署 Mix Space **前端** *（为什么分开部署？请查看 [一些你需要知道的事情](#一些你需要知道的事情)）*

--- a/pages/docs/index.mdx
+++ b/pages/docs/index.mdx
@@ -38,7 +38,7 @@ import { UilExternalLinkAlt } from '@components/Icons/ExternalLinkAlt';
   <Card arrow title="预设脚本部署" href="/docs/scripts" icon={<UilPaintTool />} />
   <Card arrow title="进阶部署" href="/docs/advanced" icon={<UimStar />} />
   <Card arrow title="社区部署教程" href="/docs/community" icon={<FluentPeopleCommunity />} />
-  <Card arrow title="拓展内容" href="/docs/extra" icon={<UilExternalLinkAlt />} />
+  <Card arrow title="部署扩展内容" href="/docs/extra" icon={<UilExternalLinkAlt />} />
 </Cards>
 
 还有更多部署方式吗？欢迎您向文档提交 [Pull Request](https://github.com/mx-space/docs/pulls) 以分享您的部署方式。按上方**后端部署文档**完成你的部署后，你可以通过下面的方式继续部署 Mix Space **前端** *（为什么分开部署？请查看 [一些你需要知道的事情](#一些你需要知道的事情)）*


### PR DESCRIPTION
### Description

```diff
- 扩展内容
+ 相关内容
```

直接写扩展内容有和「使用指南」概念出现重叠的概率：

- 扩展内容：部署章节里的扩展内容 / 除了部署章节的其他内容
- 部署扩展内容：部署章节里的扩展内容


### Linked Issues

none

### Additional context

none
